### PR TITLE
c('x', 'y') != '' returns error in R 4.0

### DIFF
--- a/R/process_query.R
+++ b/R/process_query.R
@@ -35,7 +35,7 @@ process_query<-function(library0, query = "", ppm_search = 20, rt_search = 12, s
 	if (!is.character(query)){
 		stop("Query expression is not valid!")}
 	
-	if (query!=""){
+	if (all(query!="") & (length(query) > 0)){
 		
 		indexes_list = list()
 		NI = 0


### PR DESCRIPTION
solution to issue of multiple condition process query malfunction

